### PR TITLE
user manuals: fix missing pod priorityClassName

### DIFF
--- a/docs/user-manuals/cpu-evict.md
+++ b/docs/user-manuals/cpu-evict.md
@@ -105,6 +105,8 @@ as the [example](https://github.com/koordinator-sh/charts/blob/main/versions/v1.
              kubernetes.io/batch-memory: 4Gi
      restartPolicy: Always
      schedulerName: default-scheduler
+     # priorityClassName is required when ColocationProfile enabled (default).
+     priorityClassName: koord-batch
    ```
    
 4. Run the following command to deploy the be-pod-demo pod in the cluster:

--- a/docs/user-manuals/cpu-qos.md
+++ b/docs/user-manuals/cpu-qos.md
@@ -157,6 +157,7 @@ Please make sure Koordinator components are correctly installed in your cluster.
          name: stress
      restartPolicy: Always
      schedulerName: default-scheduler
+     # priorityClassName is required when ColocationProfile enabled (default).
      priorityClassName: koord-batch
    ```
 

--- a/docs/user-manuals/memory-evict.md
+++ b/docs/user-manuals/memory-evict.md
@@ -93,6 +93,8 @@ as the [example](https://github.com/koordinator-sh/charts/blob/main/versions/v1.
          name: stress
      restartPolicy: Always
      schedulerName: default-scheduler
+     # priorityClassName is required when ColocationProfile enabled (default).
+     priorityClassName: koord-batch
    ```
 
 4. Run the following command to deploy the be-pod-demo pod in the cluster:

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-manuals/cpu-evict.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-manuals/cpu-evict.md
@@ -100,6 +100,8 @@ Koordinator提供了CPU的[动态压制能力](/docs/user-manuals/cpu-suppress)�
              kubernetes.io/batch-memory: 4Gi
      restartPolicy: Always
      schedulerName: default-scheduler
+     # 当ColocationProfile功能开启时（默认启用），priorityClassName是必填的
+     priorityClassName: koord-batch
    ```
 
 4. 执行以下命令，将be-pod-demo部署到集群。

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-manuals/cpu-qos.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-manuals/cpu-qos.md
@@ -162,6 +162,7 @@ Kubernetes支持将多种类型的应用以容器化的方式部署在同一台�
          name: stress
      restartPolicy: Always
      schedulerName: default-scheduler
+     # 当ColocationProfile功能开启时（默认启用），priorityClassName是必填的
      priorityClassName: koord-batch
    ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-manuals/memory-evict.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-manuals/memory-evict.md
@@ -84,6 +84,8 @@ Koordinator支持了将节点空闲资源动态超卖给低优先级Pod，在混
          name: stress
      restartPolicy: Always
      schedulerName: default-scheduler
+     # 当ColocationProfile功能开启时（默认启用），priorityClassName是必填的
+     priorityClassName: koord-batch
    ```
 
 4. 执行以下命令，将be-pod-demo部署到集群。

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v1.3/user-manuals/cpu-evict.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v1.3/user-manuals/cpu-evict.md
@@ -100,6 +100,8 @@ Koordinator提供了CPU的[动态压制能力](/docs/user-manuals/cpu-suppress)�
              kubernetes.io/batch-memory: 4Gi
      restartPolicy: Always
      schedulerName: default-scheduler
+     # 当ColocationProfile功能开启时（默认启用），priorityClassName是必填的
+     priorityClassName: koord-batch
    ```
 
 4. 执行以下命令，将be-pod-demo部署到集群。

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v1.3/user-manuals/cpu-qos.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v1.3/user-manuals/cpu-qos.md
@@ -162,6 +162,7 @@ Kubernetes支持将多种类型的应用以容器化的方式部署在同一台�
          name: stress
      restartPolicy: Always
      schedulerName: default-scheduler
+     # 当ColocationProfile功能开启时（默认启用），priorityClassName是必填的
      priorityClassName: koord-batch
    ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v1.3/user-manuals/memory-evict.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v1.3/user-manuals/memory-evict.md
@@ -84,6 +84,8 @@ Koordinator支持了将节点空闲资源动态超卖给低优先级Pod，在混
          name: stress
      restartPolicy: Always
      schedulerName: default-scheduler
+     # 当ColocationProfile功能开启时（默认启用），priorityClassName是必填的
+     priorityClassName: koord-batch
    ```
 
 4. 执行以下命令，将be-pod-demo部署到集群。

--- a/versioned_docs/version-v1.3/user-manuals/cpu-evict.md
+++ b/versioned_docs/version-v1.3/user-manuals/cpu-evict.md
@@ -105,6 +105,8 @@ as the [example](https://github.com/koordinator-sh/charts/blob/main/versions/v1.
              kubernetes.io/batch-memory: 4Gi
      restartPolicy: Always
      schedulerName: default-scheduler
+     # priorityClassName is required when ColocationProfile enabled (default).
+     priorityClassName: koord-batch
    ```
    
 4. Run the following command to deploy the be-pod-demo pod in the cluster:

--- a/versioned_docs/version-v1.3/user-manuals/cpu-qos.md
+++ b/versioned_docs/version-v1.3/user-manuals/cpu-qos.md
@@ -157,6 +157,7 @@ Please make sure Koordinator components are correctly installed in your cluster.
          name: stress
      restartPolicy: Always
      schedulerName: default-scheduler
+     # priorityClassName is required when ColocationProfile enabled (default).
      priorityClassName: koord-batch
    ```
 

--- a/versioned_docs/version-v1.3/user-manuals/memory-evict.md
+++ b/versioned_docs/version-v1.3/user-manuals/memory-evict.md
@@ -93,6 +93,8 @@ as the [example](https://github.com/koordinator-sh/charts/blob/main/versions/v1.
          name: stress
      restartPolicy: Always
      schedulerName: default-scheduler
+     # priorityClassName is required when ColocationProfile enabled (default).
+     priorityClassName: koord-batch
    ```
 
 4. Run the following command to deploy the be-pod-demo pod in the cluster:


### PR DESCRIPTION
## ChangeLogs

1. Fix the missing pod priorityClassName in user manuals as the ColocationProfile webhook requires BE pods set priority class by default.
