### PR TITLE
Update runtime-proxy.md

### DIFF
--- a/docs/designs/runtime-proxy.md
+++ b/docs/designs/runtime-proxy.md
@@ -139,9 +139,8 @@ Firstly, please make sure your runtime backend is containerd or dockerd.
 Under containerd scenario, koord-runtime-proxy can be setup with command:
 ```
 koord-runtime-proxy --remote-runtime-service-endpoint=<runtime sockfile path>
-    --remote-image-service-endpoint=<image sockfile path>
 ```
-If containerd listening CRI request on default /var/run/koord-runtimeproxy/runtimeproxy.sock, koord-runtime-proxy can be setup by:
+If containerd listening CRI request on default /var/run/containerd/containerd.sock, koord-runtime-proxy can be setup by:
 ```
 koord-runtime-proxy
 ```


### PR DESCRIPTION

```sh
./bin/koord-runtime-proxy -h
Usage of ./bin/koord-runtime-proxy:
      --backend-runtime-mode string              backend container engine(Containerd|Docker). (default "Containerd")
      --koord-runtimeproxy-endpoint string       koord-runtimeproxy service endpoint. (default "/var/run/koord-runtimeproxy/runtimeproxy.sock")
      --remote-runtime-service-endpoint string   backend runtime service endpoint. (default "/var/run/containerd/containerd.sock")
      --runtime-hook-server-key string           if pod tag itself with runtime-hook-server-key in annotations, runtime-proxy would regard this pod as runtime hook server and skip transferring cri events to hook server (default "runtimeproxy.koordinator.sh/skip-hookserver")
      --runtime-hook-server-val string           working combined with runtime-hook-server-key (default "true")
pflag: help requested
```