### PR TITLE
website: add zh-Hans website footer with CNCF messages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -174,7 +174,7 @@ const config = {
         copyright: `
         <div style="font-size: 18px">
         <br />
-        <strong>Koordinator is a <a href="https://www.cncf.io/">Cloud Native Computing Foundation</a> sandbox project.</strong>
+        <strong>Koordinator is a <a href="https://www.cncf.io/">Cloud Native Computing Foundation</a> sandbox project</strong>
         <br />
         </div>
         <br />

--- a/i18n/zh-Hans/docusaurus-theme-classic/footer.json
+++ b/i18n/zh-Hans/docusaurus-theme-classic/footer.json
@@ -40,7 +40,7 @@
     "description": "The label of footer link with label=Blog linking to blog"
   },
   "copyright": {
-    "message": "\n        <br />\n        <strong>Copyright © 2022 The Koordinator Authors. All rights reserved.</strong>",
+    "message": "\n        <div style=\"font-size: 18px\">\n        <br />\n        <strong>Koordinator是 <a href=\"https://www.cncf.io/\">Cloud Native Computing Foundation</a> 沙箱项目 </strong>\n        <br />\n        </div>\n        <br />\n        <img src=\"img/cncf-color.svg\" alt=\"CNCF\" width=\"auto\" height=\"100px\"/>\n        <br />\n        <div style=\"font-size: 14px\">\n        Linux基金会® (TLF) 已注册并使用商标。如需了解Linux基金会的商标列表，请访问<a href=\"https://www.linuxfoundation.org/trademark-usage/\">商标使用</a>页面。\n        <br />\n        Copyright © 2024 Koordinator项目作者。保留所有权利。\n        </div>\n        ",
     "description": "The footer copyright"
   }
 }


### PR DESCRIPTION
This PR added CNCF messages in website footer of zh-Hans pages.

The translation refers to [Kubernetes](https://kubernetes.io/zh-cn/): 
![image](https://github.com/koordinator-sh/website/assets/110808397/cf430f8e-51f6-4da1-9bfd-7287c20e1163)
