### PR TITLE
  fix(sidebars): remove accidental console.log

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -175,5 +175,3 @@ const sidebars = {
 };
 
 module.exports = sidebars;
-
-console.log(JSON.stringify(sidebars, null, 2))


### PR DESCRIPTION
### Problem
`sidebars.js` line 179 has `console.log(JSON.stringify(sidebars, null, 2))`. Docusaurus requires this file as a Node module, so this executes on every `npm run build`, `npm run start`, and `docusaurus docs:version` call. It prints ~150 lines of JSON to stdout, flooding build output and CI logs.

### Expected
The `console.log` should not exist in a config file.

  - Remove `console.log(JSON.stringify(sidebars, null, 2))` from the end of `sidebars.js` — this line executed on every build and dev-server start, printing ~150 lines of JSON to stdout and flooding CI logs

  ## Files Changed

  - `sidebars.js` — deleted line 179 (the console.log call)