### PR TITLE
fix(config): correct editUrl repo name in docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -57,7 +57,7 @@ const config = {
             locale,
             docPath,
           }) {
-            return `https://github.com/koordinator-sh/koordinator.sh/edit/main/docs/${docPath}`;
+            return `https://github.com/koordinator-sh/website/edit/main/docs/${docPath}`;
           },
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
@@ -78,7 +78,7 @@ const config = {
           showReadingTime: true,
           // Please change this to your repo.
           editUrl:
-            'https://github.com/koordinator-sh/koordinator.sh/edit/main/',
+            'https://github.com/koordinator-sh/website/edit/main/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
The `editUrl` in `docusaurus.config.js` was pointing to `koordinator-sh/koordinator.sh` which doesn't exist, so every "Edit this page" link across the docs and blog was 404ing.

Fixed both occurrences — the docs `editUrl` function (line 60) and the blog `editUrl` string (line 81) — to point to `koordinator-sh/website`.
