### PR TITLE
  docs(user-manuals): update deprecated v1beta2 scheduler API to v1

### DIFF
--- a/docs/user-manuals/capacity-scheduling.md
+++ b/docs/user-manuals/capacity-scheduling.md
@@ -548,7 +548,7 @@ metadata:
   namespace: {{ .Values.installation.namespace }}
 data:
   koord-scheduler-config: |
-    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    apiVersion: kubescheduler.config.k8s.io/v1
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: true
@@ -559,7 +559,7 @@ data:
       - pluginConfig:
         - name: ElasticQuota
           args:
-            apiVersion: kubescheduler.config.k8s.io/v1beta2
+            apiVersion: kubescheduler.config.k8s.io/v1
             kind: ElasticQuotaArgs
             quotaGroupNamespace: {{ .Values.installation.namespace }}
             enableCheckParentQuota: true

--- a/docs/user-manuals/gang-scheduling.md
+++ b/docs/user-manuals/gang-scheduling.md
@@ -343,7 +343,7 @@ metadata:
   namespace: {{ .Values.installation.namespace }}
 data:
   koord-scheduler-config: |
-    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    apiVersion: kubescheduler.config.k8s.io/v1
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: true
@@ -354,7 +354,7 @@ data:
       - pluginConfig:
         - name: Coscheduling
         args:
-            apiVersion: kubescheduler.config.k8s.io/v1beta2
+            apiVersion: kubescheduler.config.k8s.io/v1
             kind: CoschedulingArgs
             defaultTimeout: 600s
  	        controllerWorkers: 1

--- a/versioned_docs/version-v1.8/user-manuals/capacity-scheduling.md
+++ b/versioned_docs/version-v1.8/user-manuals/capacity-scheduling.md
@@ -548,7 +548,7 @@ metadata:
   namespace: {{ .Values.installation.namespace }}
 data:
   koord-scheduler-config: |
-    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    apiVersion: kubescheduler.config.k8s.io/v1
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: true
@@ -559,7 +559,7 @@ data:
       - pluginConfig:
         - name: ElasticQuota
           args:
-            apiVersion: kubescheduler.config.k8s.io/v1beta2
+            apiVersion: kubescheduler.config.k8s.io/v1
             kind: ElasticQuotaArgs
             quotaGroupNamespace: {{ .Values.installation.namespace }}
             enableCheckParentQuota: true

--- a/versioned_docs/version-v1.8/user-manuals/gang-scheduling.md
+++ b/versioned_docs/version-v1.8/user-manuals/gang-scheduling.md
@@ -343,7 +343,7 @@ metadata:
   namespace: {{ .Values.installation.namespace }}
 data:
   koord-scheduler-config: |
-    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    apiVersion: kubescheduler.config.k8s.io/v1
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: true
@@ -354,7 +354,7 @@ data:
       - pluginConfig:
         - name: Coscheduling
         args:
-            apiVersion: kubescheduler.config.k8s.io/v1beta2
+            apiVersion: kubescheduler.config.k8s.io/v1
             kind: CoschedulingArgs
             defaultTimeout: 600s
  	        controllerWorkers: 1


### PR DESCRIPTION
## Summary

  - Replace `kubescheduler.config.k8s.io/v1beta2` with `kubescheduler.config.k8s.io/v1` in all `KubeSchedulerConfiguration` examples — `v1beta2` was removed in
  Kubernetes 1.26 and will error on any cluster running >= 1.26

  ## Files Changed

  - `docs/user-manuals/capacity-scheduling.md` — 2 occurrences updated (KubeSchedulerConfiguration and ElasticQuotaArgs apiVersion)
  - `docs/user-manuals/gang-scheduling.md` — 2 occurrences updated (KubeSchedulerConfiguration and CoschedulingArgs apiVersion)
  - `versioned_docs/version-v1.8/user-manuals/capacity-scheduling.md` — same 2 occurrences
  - `versioned_docs/version-v1.8/user-manuals/gang-scheduling.md` — same 2 occurrences

Fixes #332 
