### PR TITLE
chore(ci): upgrade checkout and setup-node actions to v4

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -13,8 +13,8 @@ jobs:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '19.x'
       - name: Test Build
@@ -31,11 +31,11 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '19.x'
-      - uses: webfactory/ssh-agent@v0.5.0
+      - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}
       - name: Release to GitHub Pages


### PR DESCRIPTION
### Problem
`.github/workflows/documentation.yaml` uses `actions/checkout@v1` and `actions/setup-node@v1`. v1 of both actions is deprecated and has security warnings. Current versions are `actions/checkout@v4` and `actions/setup-node@v4`.

## Fixes
  - Upgrade `actions/checkout@v1` → `actions/checkout@v4` in both `checks` and `gh-release` jobs
  - Upgrade `actions/setup-node@v1` → `actions/setup-node@v4` in both jobs
  - Upgrade `webfactory/ssh-agent@v0.5.0` → `webfactory/ssh-agent@v0.9.0` in `gh-release` job