### PR TITLE
  fix(slo-config): add missing comma in system-config JSON example

### DIFF
--- a/docs/user-manuals/slo-config.md
+++ b/docs/user-manuals/slo-config.md
@@ -313,7 +313,7 @@ data:
         "minFreeKbytesFactor": 100,
         "watermarkScaleFactor": 150,
         "memcgReapBackGround": 0
-      }
+      },
       "nodeStrategies": [
         {
           "name": "anolis",

--- a/versioned_docs/version-v1.8/user-manuals/slo-config.md
+++ b/versioned_docs/version-v1.8/user-manuals/slo-config.md
@@ -313,7 +313,7 @@ data:
         "minFreeKbytesFactor": 100,
         "watermarkScaleFactor": 150,
         "memcgReapBackGround": 0
-      }
+      },
       "nodeStrategies": [
         {
           "name": "anolis",


### PR DESCRIPTION
  ## Summary

  - Add missing comma after the `clusterStrategy` closing brace in the `system-config` JSON block — the JSON was syntactically invalid and would produce a parse  
  error in `koord-manager` if copied into a ConfigMap as-is

  ## Files Changed

  - `docs/user-manuals/slo-config.md` — added `,` after `clusterStrategy` closing `}` (line 316)
  - `versioned_docs/version-v1.8/user-manuals/slo-config.md` — same fix

  ## Testing

  - [x] `npm run build` passes locally
  - [x] Checked `versioned_docs/version-v1.8/` for same issue — fixed
  - [x] Checked `i18n/zh-Hans/` counterpart — both `current/user-manuals/slo-config.md` and `version-v1.8/user-manuals/slo-config.md` exist and have the same bug;
   translation team needs to apply the same comma fix

  ## Related

Fixes #336 