### PR TITLE
  fix(docs): update stale helm version and fix helms/Namepspace typos

### DIFF
--- a/docs/best-practices/batch-colocation-quick-start.md
+++ b/docs/best-practices/batch-colocation-quick-start.md
@@ -98,7 +98,7 @@ helm repo update
 Install Koordinator (latest stable version):
 
 ```bash
-helm install koordinator koordinator-sh/koordinator --version 1.6.0
+helm install koordinator koordinator-sh/koordinator --version 1.8.0
 ```
 
 Verify the installation:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ You can get more info form [here](https://kubernetes.io/docs/reference/command-l
 
 For the best experience, koordinator recommends **linux kernel 4.19** or higher.
 
-## Install with helms
+## Install with helm
 
 Koordinator can be simply installed by helm v3.5+, which is a simple command-line tool, and you can get it from [here](https://github.com/helm/helm/releases).
 

--- a/docs/user-manuals/colocation-profile.md
+++ b/docs/user-manuals/colocation-profile.md
@@ -50,7 +50,7 @@ If you are not familiar with Kubernetes resources please refer to the page [Unde
 
 ### Create ClusterColocationProfile
 
-The `profile.yaml` file below describes to modify Pod in Namepspace with label `koordinator.sh/enable-colocation=true` and inject Koordinator QoS, Koordinator Priority etc.
+The `profile.yaml` file below describes to modify Pod in Namespace with label `koordinator.sh/enable-colocation=true` and inject Koordinator QoS, Koordinator Priority etc.
 
 ```yaml
 apiVersion: config.koordinator.sh/v1alpha1

--- a/versioned_docs/version-v1.8/best-practices/batch-colocation-quick-start.md
+++ b/versioned_docs/version-v1.8/best-practices/batch-colocation-quick-start.md
@@ -98,7 +98,7 @@ helm repo update
 Install Koordinator (latest stable version):
 
 ```bash
-helm install koordinator koordinator-sh/koordinator --version 1.6.0
+helm install koordinator koordinator-sh/koordinator --version 1.8.0
 ```
 
 Verify the installation:

--- a/versioned_docs/version-v1.8/installation.md
+++ b/versioned_docs/version-v1.8/installation.md
@@ -7,7 +7,7 @@ You can get more info form [here](https://kubernetes.io/docs/reference/command-l
 
 For the best experience, koordinator recommends **linux kernel 4.19** or higher.
 
-## Install with helms
+## Install with helm
 
 Koordinator can be simply installed by helm v3.5+, which is a simple command-line tool, and you can get it from [here](https://github.com/helm/helm/releases).
 

--- a/versioned_docs/version-v1.8/user-manuals/colocation-profile.md
+++ b/versioned_docs/version-v1.8/user-manuals/colocation-profile.md
@@ -50,7 +50,7 @@ If you are not familiar with Kubernetes resources please refer to the page [Unde
 
 ### Create ClusterColocationProfile
 
-The `profile.yaml` file below describes to modify Pod in Namepspace with label `koordinator.sh/enable-colocation=true` and inject Koordinator QoS, Koordinator Priority etc.
+The `profile.yaml` file below describes to modify Pod in Namespace with label `koordinator.sh/enable-colocation=true` and inject Koordinator QoS, Koordinator Priority etc.
 
 ```yaml
 apiVersion: config.koordinator.sh/v1alpha1


### PR DESCRIPTION
  ## Summary

  - Update `--version 1.6.0` to `--version 1.8.0` in the Batch Colocation Quick Start guide
  - Fix heading typo "Install with helms" → "Install with helm" in installation guide
  - Fix prose typo "Namepspace" → "Namespace" in colocation-profile guide

  ## Files Changed

  - `docs/best-practices/batch-colocation-quick-start.md` — updated Helm install version from 1.6.0 to 1.8.0
  - `docs/installation.md` — fixed "helms" → "helm" in section heading
  - `docs/user-manuals/colocation-profile.md` — fixed "Namepspace" → "Namespace" in prose
  - `versioned_docs/version-v1.8/best-practices/batch-colocation-quick-start.md` — same version fix
  - `versioned_docs/version-v1.8/installation.md` — same heading fix
  - `versioned_docs/version-v1.8/user-manuals/colocation-profile.md` — same typo fix

  ## Testing

  - [x] `npm run build` passes locally
  - [x] Checked `versioned_docs/version-v1.8/` for same issues — all three fixed
  - [x] Checked `i18n/zh-Hans/` counterparts — all three exist; translation team should apply the same fixes to `current/` and `version-v1.8/` zh-Hans files      

  ## Related

Fixes #338 