### PR TITLE
 fix(docs): correct prerequisite version typos 0.71/0.70 to v0.7

### DIFF
--- a/docs/user-manuals/capacity-scheduling.md
+++ b/docs/user-manuals/capacity-scheduling.md
@@ -18,7 +18,7 @@ resources from the idle quota groups, the resources can be allocated to the busy
 ### Prerequisite
 
 - Kubernetes >= 1.18
-- Koordinator >= 0.71
+- Koordinator >= v0.7
 
 ### Installation
 

--- a/docs/user-manuals/fine-grained-device-scheduling.md
+++ b/docs/user-manuals/fine-grained-device-scheduling.md
@@ -18,7 +18,7 @@ through the scheduler to obtain globally optimal allocation results.
 ### Prerequisite
 
 - Kubernetes >= 1.18
-- Koordinator >= 0.71
+- Koordinator >= v0.7
 
 ### Installation
 

--- a/docs/user-manuals/gang-scheduling.md
+++ b/docs/user-manuals/gang-scheduling.md
@@ -11,7 +11,7 @@ the real scenario, which is different from community.
 ### Prerequisite
 
 - Kubernetes >= 1.18
-- Koordinator >= 0.70
+- Koordinator >= v0.7
 
 ### Installation
 

--- a/versioned_docs/version-v1.8/user-manuals/capacity-scheduling.md
+++ b/versioned_docs/version-v1.8/user-manuals/capacity-scheduling.md
@@ -18,7 +18,7 @@ resources from the idle quota groups, the resources can be allocated to the busy
 ### Prerequisite
 
 - Kubernetes >= 1.18
-- Koordinator >= 0.71
+- Koordinator >= v0.7
 
 ### Installation
 

--- a/versioned_docs/version-v1.8/user-manuals/fine-grained-device-scheduling.md
+++ b/versioned_docs/version-v1.8/user-manuals/fine-grained-device-scheduling.md
@@ -18,7 +18,7 @@ through the scheduler to obtain globally optimal allocation results.
 ### Prerequisite
 
 - Kubernetes >= 1.18
-- Koordinator >= 0.71
+- Koordinator >= v0.7
 
 ### Installation
 

--- a/versioned_docs/version-v1.8/user-manuals/gang-scheduling.md
+++ b/versioned_docs/version-v1.8/user-manuals/gang-scheduling.md
@@ -11,7 +11,7 @@ the real scenario, which is different from community.
 ### Prerequisite
 
 - Kubernetes >= 1.18
-- Koordinator >= 0.70
+- Koordinator >= v0.7
 
 ### Installation
 


### PR DESCRIPTION
## Summary

- Fix non-existent version numbers `0.71` and `0.70` in prerequisite sections — the 0.x series only had v0.6 and v0.7; these versions were never released
- Add missing `v` prefix per project versioning convention

## Files Changed

- `docs/user-manuals/capacity-scheduling.md` — `0.71` → `v0.7`
- `docs/user-manuals/gang-scheduling.md` — `0.70` → `v0.7`
- `docs/user-manuals/fine-grained-device-scheduling.md` — `0.71` → `v0.7`
- `versioned_docs/version-v1.8/user-manuals/capacity-scheduling.md` — same fix
- `versioned_docs/version-v1.8/user-manuals/gang-scheduling.md` — same fix
- `versioned_docs/version-v1.8/user-manuals/fine-grained-device-scheduling.md` — same fix

## Testing

- [x] `npm run build` passes locally
- [x] Checked versioned_docs/version-v1.8/ — same fix applied
- [x] i18n/zh-Hans/ counterparts exist — Chinese versions will need the same fi