### PR TITLE
fix(docs): yaml code block for bash command and remove duplicate sentence

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -289,7 +289,7 @@ kubeadmConfigPatches:
 
 Then create the cluster:
 
-```yaml
+```bash
 kind create cluster --config=kind-config.yaml
 ```
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -27,8 +27,6 @@ Koordinator enhances the kubernetes user experiences in the workload management 
 
 Kubernetes provides three types of QoS: Guaranteed/Burstable/BestEffort, of which Guaranteed/Burstable is widely used and BestEffort is rarely used. Koordinator is compatible with Kubernetes QoS and has numerous enhancements on each type. In order to avoid interfering with the native QoS semantics, Koordinator introduces an independent field ```koordinator.sh/qosClass``` to describe the co-location QoS. This QoS describes the service quality of the Pod running on the node in the co-location scenario. It is the most critical semantics of the mixed system.
 
-Koordinator is compatible with Kubernetes QoS and has numerous enhancements on each type.
-
 ### Koordinator scheduler vs kube-scheduler
 
 Koordinator scheduler is **not** designed to replace kube-scheduler, but to make co-located workloads run **better** on kubernetes.

--- a/versioned_docs/version-v1.8/installation.md
+++ b/versioned_docs/version-v1.8/installation.md
@@ -289,7 +289,7 @@ kubeadmConfigPatches:
 
 Then create the cluster:
 
-```yaml
+```bash
 kind create cluster --config=kind-config.yaml
 ```
 

--- a/versioned_docs/version-v1.8/introduction.md
+++ b/versioned_docs/version-v1.8/introduction.md
@@ -27,8 +27,6 @@ Koordinator enhances the kubernetes user experiences in the workload management 
 
 Kubernetes provides three types of QoS: Guaranteed/Burstable/BestEffort, of which Guaranteed/Burstable is widely used and BestEffort is rarely used. Koordinator is compatible with Kubernetes QoS and has numerous enhancements on each type. In order to avoid interfering with the native QoS semantics, Koordinator introduces an independent field ```koordinator.sh/qosClass``` to describe the co-location QoS. This QoS describes the service quality of the Pod running on the node in the co-location scenario. It is the most critical semantics of the mixed system.
 
-Koordinator is compatible with Kubernetes QoS and has numerous enhancements on each type.
-
 ### Koordinator scheduler vs kube-scheduler
 
 Koordinator scheduler is **not** designed to replace kube-scheduler, but to make co-located workloads run **better** on kubernetes.


### PR DESCRIPTION
## Summary

- `installation.md`: change ` ```yaml ` to ` ```bash ` for the `kind create cluster` shell command — shell commands must not use yaml syntax highlighting
- `introduction.md`: remove duplicate sentence "Koordinator is compatible with Kubernetes QoS and has numerous enhancements on each type." that appeared twice in sequence

## Files Changed

- `docs/installation.md` — fix code fence language
- `versioned_docs/version-v1.8/installation.md` — same fix
- `docs/introduction.md` — remove duplicate sentence
- `versioned_docs/version-v1.8/introduction.md` — same fix

## Testing

- [x] `npm run build` passes locally
- [x] Checked versioned_docs/version-v1.8/ — same fixes applied
- [x] i18n/zh-Hans/ counterparts exist — Chinese versions will need the same fixes

## Related

Closes #341 