### PR TITLE
docs: fix Cambricon MLU prerequisite wording

### DIFF
--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-manuals/device-scheduling-cambricon-mlu.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-manuals/device-scheduling-cambricon-mlu.md
@@ -8,7 +8,7 @@
 
 ### 前置条件
 
-昇腾卡的使用需要提前安装配置如下组件
+寒武纪卡的使用需要提前安装配置如下组件
 - 寒武纪 Driver
 - 寒武纪 [Cambricon Device Plugin (开启虚拟化参数配置)](https://github.com/Cambricon/cambricon-k8s-device-plugin)
 ```yaml dynamic-smlu 启动参数

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v1.7/user-manuals/device-scheduling-cambricon-mlu.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v1.7/user-manuals/device-scheduling-cambricon-mlu.md
@@ -8,7 +8,7 @@
 
 ### 前置条件
 
-昇腾卡的使用需要提前安装配置如下组件
+寒武纪卡的使用需要提前安装配置如下组件
 - 寒武纪 Driver
 - 寒武纪 [Cambricon Device Plugin (开启虚拟化参数配置)](https://github.com/Cambricon/cambricon-k8s-device-plugin)
 ```yaml dynamic-smlu 启动参数

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v1.8/user-manuals/device-scheduling-cambricon-mlu.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v1.8/user-manuals/device-scheduling-cambricon-mlu.md
@@ -8,7 +8,7 @@
 
 ### 前置条件
 
-昇腾卡的使用需要提前安装配置如下组件
+寒武纪卡的使用需要提前安装配置如下组件
 - 寒武纪 Driver
 - 寒武纪 [Cambricon Device Plugin (开启虚拟化参数配置)](https://github.com/Cambricon/cambricon-k8s-device-plugin)
 ```yaml dynamic-smlu 启动参数


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Fixes the prerequisite wording in the Chinese Cambricon MLU device scheduling docs.

The page currently says "昇腾卡的使用需要提前安装配置如下组件", which should be "寒武纪卡" instead.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

Checked the updated markdown content.

### Ⅳ. Special notes for reviews

Docs-only change.

### V. Checklist

- [x] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`